### PR TITLE
Fix PostCSS Custom Media by importing the @custom-media queries from variables

### DIFF
--- a/plugins/css.js
+++ b/plugins/css.js
@@ -6,7 +6,12 @@ module.exports = {
     {
       resolve: `gatsby-plugin-postcss`,
       options: {
-        postCssPlugins: [customMedia(), autoprefixer()]
+        postCssPlugins: [
+          customMedia({
+            importFrom: `${__dirname}/../src/css/_variables.css`
+          }),
+          autoprefixer()
+        ]
       }
     }
   ]


### PR DESCRIPTION
Closes #19 

This fixes PostCSS @custom-media queries from not importing correctly. It's not the cleanest solution, but we manually import the media queries in the config.

## How to verify it's working

1. Fire up dev server, don't save any files to trigger HMR
1. Go to `/work`. Expand viewport to desktop size
1. Observe 3-column layout for Work items