### PR TITLE
Add line numbers to code blocks

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,3 @@
-require('prismjs/themes/prism-tomorrow.css');
-// TODO: Figure out why this isn't working
-require('prismjs/plugins/line-numbers/prism-line-numbers.css');
-
 const consoleGreetingFirstLine = `Hi there! 👋`;
 const consoleGreeting = `
 Thanks for checking out my website! If you're seeing this,

--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -9,6 +9,54 @@ module.exports = {
         gfm: true,
         plugins: [
           {
+            resolve: `gatsby-remark-prismjs`,
+            options: {
+              // Class prefix for <pre> tags containing syntax highlighting;
+              // defaults to 'language-' (eg <pre class="language-js">).
+              // If your site loads Prism into the browser at runtime,
+              // (eg for use with libraries like react-live),
+              // you may use this to prevent Prism from re-processing syntax.
+              // This is an uncommon use-case though;
+              // If you're unsure, it's best to use the default value.
+              classPrefix: 'language-',
+              // This is used to allow setting a language for inline code
+              // (i.e. single backticks) by creating a separator.
+              // This separator is a string and will do no white-space
+              // stripping.
+              // A suggested value for English speakers is the non-ascii
+              // character '›'.
+              inlineCodeMarker: null,
+              // This lets you set up language aliases.  For example,
+              // setting this to '{ sh: "bash" }' will let you use
+              // the language "sh" which will highlight using the
+              // bash highlighter.
+              aliases: {},
+              // This toggles the display of line numbers globally alongside the code.
+              // To use it, add the following line in src/layouts/index.js
+              // right after importing the prism color scheme:
+              //  `require("prismjs/plugins/line-numbers/prism-line-numbers.css");`
+              // Defaults to false.
+              // If you wish to only show line numbers on certain code blocks,
+              // leave false and use the {numberLines: true} syntax below
+              showLineNumbers: true,
+              // If setting this to true, the parser won't handle and highlight inline
+              // code used in markdown i.e. single backtick code like `this`.
+              noInlineHighlight: false,
+              // This adds a new language definition to Prism or extend an already
+              // existing language definition. More details on this option can be
+              // found under the header "Add new language definition or extend an
+              // existing language" below.
+              languageExtensions: [],
+              // Customize the prompt used in shell output
+              // Values below are default
+              prompt: {
+                user: 'root',
+                host: 'localhost',
+                global: false
+              }
+            }
+          },
+          {
             resolve: `gatsby-remark-images-contentful`,
             options: {
               // It's important to specify the maxWidth (in pixels) of
@@ -22,29 +70,8 @@ module.exports = {
           },
           `gatsby-remark-embedder`,
           `gatsby-remark-copy-linked-files`,
-          'gatsby-remark-responsive-iframe',
-          `gatsby-remark-prismjs`
+          'gatsby-remark-responsive-iframe'
         ]
-      }
-    },
-    {
-      resolve: `gatsby-remark-prismjs`,
-      options: {
-        // Class prefix for <pre> tags containing syntax highlighting;
-        // defaults to 'language-' (eg <pre class="language-js">).
-        classPrefix: 'language-',
-        // This is used to allow setting a language for inline code
-        // (i.e. single backticks) by creating a separator.
-        inlineCodeMarker: null,
-        aliases: {},
-        showLineNumbers: false,
-        noInlineHighlight: false,
-        languageExtensions: [],
-        prompt: {
-          user: 'root',
-          host: 'localhost',
-          global: false
-        }
       }
     }
   ]

--- a/src/components/Blog/BlogPost/index.tsx
+++ b/src/components/Blog/BlogPost/index.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, RefObject } from 'react';
+import React, { useRef } from 'react';
 import shortid from 'shortid';
 
 import Page from '../../Layout/Page';
 import Comments from '../Comments';
+import 'prismjs/themes/prism-tomorrow.css';
 import styles from './BlogPost.module.css';
 import BlogPostNewsletterSignup from '../BlogPostNewsletterSignup';
 import { useMediumZoom } from './BlogPostHooks';

--- a/src/css/_prismjs.css
+++ b/src/css/_prismjs.css
@@ -9,65 +9,85 @@ pre {
  * and overflow that we removed from <pre>.
  */
 .gatsby-highlight {
+  width: 100%;
+  margin-top: var(--typography-marginRhythm);
   margin-bottom: var(--typography-marginRhythm);
-  border-radius: 0.3em;
+  font-size: 0.8421rem;
   overflow: auto;
   scroll-behavior: smooth;
-  background: var(--bg-code-block-bright); /* Matches PrismJS Tomorrow theme */
 }
 
-/**
- * Remove the default PrismJS theme background-color, border-radius, margin,
- * padding and overflow.
- * 1. Make the element just wide enough to fit its content.
- * 2. Always fill the visible space in .gatsby-highlight.
- * 3. Adjust the position of the line numbers
- */
 .gatsby-highlight pre[class*='language-'] {
-  margin: 0;
-  overflow: initial;
-  min-width: 100%;
-}
-
-.gatsby-highlight-code-line {
-  background-color: #feb;
   display: block;
-  margin-right: -1em;
-  margin-left: -1em;
-  padding-right: 1em;
-  padding-left: 0.75em;
-  border-left: 0.25em solid #f99;
+  width: 100%;
+  padding: 1rem;
+  margin: 0;
+  border-radius: 4px;
+  background-color: var(--bg-code-block-dark);
+  /* 
+   * Flexbox can break right padding on <pre> element
+   * Using float fixes it.
+   * https://stackoverflow.com/questions/26888428/display-flex-loses-right-padding-when-overflowing
+   */
+  float: left;
 }
 
-/* Adjust the position of the line numbers */
 .gatsby-highlight pre[class*='language-'].line-numbers {
-  padding-left: 2.8em;
+  display: flex;
+  padding: 10px;
+  counter-reset: linenumber;
 }
 
-/*************************/
-/* Personal adjustments */
+.gatsby-highlight pre[class*='language-'].line-numbers > code {
+  width: 100%;
+  order: 2;
+}
 
-.gatsby-highlight {
-  font-size: 0.8421rem;
+.gatsby-highlight pre[class*='language-'].line-numbers .line-numbers-rows {
+  position: static;
+  height: 100%;
+  padding: 0;
+  margin-right: 1rem;
+  pointer-events: none;
+  user-select: none;
+}
+
+.gatsby-highlight .line-numbers .line-numbers-rows > span {
+  pointer-events: none;
+  display: block;
+  counter-increment: linenumber;
+}
+
+.gatsby-highlight .line-numbers .line-numbers-rows > span:before {
+  content: counter(linenumber);
+  text-align: right;
+  color: var(--white-30);
 }
 
 :not(pre) > code[class*='language-'] {
   padding: 2px 4px;
   font-size: 85%;
-  border-radius: 0.15em;
+  border-radius: 0.15rem;
   background: var(--black-10);
   color: var(--color-body-copy);
 }
 
+/* Diff (+) */
 .gatsby-highlight .language-diff .token.inserted {
   color: #8fca8f;
 }
 
-@media (prefers-color-scheme: dark) {
-  .gatsby-highlight {
-    background: var(--bg-code-block-dark);
-  }
+/* Highlighted line */
+.gatsby-highlight-code-line {
+  width: 100%;
+  background-color: #263766;
+  display: block;
+  padding-right: 1rem;
+  padding-left: 0.75rem;
+  border-left: 0.25rem solid #5b70ae;
+}
 
+@media (prefers-color-scheme: dark) {
   pre[class*='language-'] {
     background: var(--bg-code-block-dark);
   }
@@ -75,5 +95,9 @@ pre {
   :not(pre) > code[class*='language-'] {
     background: var(--white-30) !important;
     color: white !important;
+  }
+
+  .gatsby-highlight .line-numbers .line-numbers-rows > span:before {
+    color: var(--white-30);
   }
 }


### PR DESCRIPTION
- Update `gatsby-config` for markdown transformer with correct PrismJS config
- Remove PrismJS code block styles to every page
- Add PrismJS code block styles to only blog posts
- Refactor code block styles